### PR TITLE
Updated browser styles to better match the Chrome URL bar in Windows

### DIFF
--- a/chrome/_browser.css
+++ b/chrome/_browser.css
@@ -142,16 +142,16 @@
   background-color: var(--textbox-background-color) !important;
   border: 0 !important;
   box-shadow: none !important;
-  margin: 1px !important;
-  padding: 2px !important;
+  margin: 4px !important;
+  padding: 0px !important;
   background-clip: padding-box !important;
 }
 
 #urlbar[focused]
 {
   box-shadow:
-    0 0 0 2px var(--textbox-outer-color-focused),
-    0 0 0 2px var(--textbox-inner-color-focused) inset !important;
+    0 0 0 1px var(--textbox-outer-color-focused),
+    0 0 0 1px var(--textbox-inner-color-focused) inset !important;
   background-color: var(--textbox-background-color-focused) !important;
 }
 


### PR DESCRIPTION
## Changes
This is a minor style update for the **URL bar** to better match the Google Chrome UI
- Updated focused style with thinner blue shadow.
- Increased the margin between the URL bar and its container (especially noticeable when having several tabs open, see screenshots).

## Screenshots
### Chrome
**Not focused | Focused**
![image](https://user-images.githubusercontent.com/7527242/44888371-0e4c1200-ac8e-11e8-8a5f-840eb48780a2.png)

### Firefox
**Focused:** Before | After
![image](https://user-images.githubusercontent.com/7527242/44888233-3dae4f00-ac8d-11e8-8747-787a9ea6683f.png)

**Not Focused:** Before | After
![image](https://user-images.githubusercontent.com/7527242/44888356-f70d2480-ac8d-11e8-8962-9fc900367bfd.png)

