### PR TITLE
Add installation intructions about macOS Mojave Dark Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Some steps involve accessing the about:config page. You can get there by typing 
 Replicate Chrome's color scheme:
 * Right click on toolbar -> Customize.
 * Click Themes.
-* Select Default theme.
+* Select Default theme (or Light theme if you're using Dark mode with macOS Mojave).
 
 Add space above tab bar:
 * Right click on toolbar -> Customize.


### PR DESCRIPTION
I guess the light theme is more accurate to Chrome so I just added this sentence to the README for macOS Mojave and Firefox <64 users.

For #41 