### PR TITLE
Bookmark folder icon fix

### DIFF
--- a/chrome/popup/popup.css
+++ b/chrome/popup/popup.css
@@ -178,7 +178,7 @@ menuseparator
 }
 
 /* unset fill-opacity for menus nested in buttons */
-.bookmark-item > menupopup
+.bookmark-item > menupopup, .toolbarbutton-1 > menupopup
 {
 	fill-opacity: initial !important;
 }


### PR DESCRIPTION
This fixes an issue where the folder arrow icon in the bookmarks overflow menu (#PlacesChevron) have the wrong color.