### PR TITLE
New flag for 69+

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Some steps involve accessing the about:config page. You can get there by typing 
 1. Copy the chrome folder into your Firefox profile directory. To find your profile directory, go to about:support. Alternatively, you can symlink your chrome folder instead of copying.
 2. [about:config] Set ```toolkit.legacyUserProfileCustomizations.stylesheets``` to ```true``` (default is ```false```).
 3. [about:config] Set ```svg.context-properties.content.enabled``` to ```true``` (default is ```false```).
-3. Restart Firefox.
+4. Restart Firefox.
 
 ### Recommended instructions
 Add space above tab bar:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Some steps involve accessing the about:config page. You can get there by typing 
 
 ### Mandatory instructions
 1. Copy the chrome folder into your Firefox profile directory. To find your profile directory, go to about:support. Alternatively, you can symlink your chrome folder instead of copying.
-2. [about:config] Set ```svg.context-properties.content.enabled``` to ```true``` (default is ```false```).
+2. [about:config] Set ```toolkit.legacyUserProfileCustomizations.stylesheets``` to ```true``` (default is ```false```).
+3. [about:config] Set ```svg.context-properties.content.enabled``` to ```true``` (default is ```false```).
 3. Restart Firefox.
 
 ### Recommended instructions


### PR DESCRIPTION
Users need to enable a flag in Firefox 69 to apply userChrome if they haven't used it in 68-.
[Read more](https://www.reddit.com/r/firefox/comments/brttne/psa_firefox_v69_users_will_have_to_set_a_pref_to/)