### PR TITLE
Change urlbar border on select to ~Chrome's

### DIFF
--- a/chrome/navbar/navbar.css
+++ b/chrome/navbar/navbar.css
@@ -95,7 +95,7 @@
 #urlbar[focused],
 #searchbar[focused]
 {
-	border: 2px solid var(--toolbar-field-focus-border-color) !important;
+	border: 2px solid #3e5b8a !important;
 	padding: 1px !important;
 	margin: 0 !important;
 }


### PR DESCRIPTION
Change urlbar border on select to ~Chrome's:
Using `#3e5b8a` instead of Firefox's var for blue

**I was unable to extract the exact color, so if anyone has a more accurate answer, be sure to say!**