### PR TITLE
Fix AppMenu's FXA Avatar margin

### DIFF
--- a/chrome/popup/popup.css
+++ b/chrome/popup/popup.css
@@ -277,6 +277,12 @@ panelview .toolbarbutton-1,
 	width: 32px !important;
 }
 
+#appMenu-fxa-avatar
+{
+	margin-inline-start: 20px !important;
+	margin-inline-end: 3px !important;
+}
+
 .toolbaritem-combined-buttons:-moz-any(:not([cui-areatype="toolbar"]),
 [overflowedItem="true"]) > toolbarbutton > .toolbarbutton-icon
 {


### PR DESCRIPTION
Hi everyone,
I edited `popup.css` to fix the alignment issue of the appmenu's Firefox Account avatar.

Before|After ✔️
---|---
![before](https://user-images.githubusercontent.com/30431538/62412140-a836e000-b5fe-11e9-81d1-a5a43946f9d9.png)|![after](https://user-images.githubusercontent.com/30431538/62412142-abca6700-b5fe-11e9-91a8-88eadf813fc6.png)

Tested on Windows 10 and Kubuntu 19.04.