### PR TITLE
Adjust connection security icons

### DIFF
--- a/chrome/urlbar/urlbar.css
+++ b/chrome/urlbar/urlbar.css
@@ -328,7 +328,7 @@
 	display: -moz-box !important;
 }
 
-#urlbar[pageproxystate=valid] #identity-box:-moz-any(.certUserOverridden, .unknownIdentity)
+#urlbar[pageproxystate=valid] #identity-box:-moz-any(.weakCipher, .certUserOverridden, .certErrorPage, .insecureLoginForms, .mixedActiveContent)
 {
 	color: #c94031 !important;
 }
@@ -680,24 +680,22 @@
 	}
 }
 
-/* info (not secure) */
-#identity-box[pageproxystate="valid"]:-moz-any(.notSecure, .insecureLoginForms, .mixedActiveContent) > #identity-icon
-{
-    list-style-image: var(--info-icon) !important;
-}
-
-#identity-box[pageproxystate="valid"]:-moz-any(
-	.certUserOverridden,
-	.weakCipher,
-	.unknownIdentity) > #identity-icon
-{
-    list-style-image: var(--warning-icon) !important;
-}
-
 /* lock (secure) */
 #identity-box[pageproxystate="valid"]:-moz-any(.verifiedDomain, .verifiedIdentity, .mixedActiveBlocked) > #identity-icon
 {
 	list-style-image: var(--lock-icon) !important;
+}
+
+/* info (not secure) */
+#identity-box[pageproxystate="valid"]:-moz-any(.mixedDisplayContent, .mixedDisplayContentLoadedActiveBlocked, .unknownIdentity) > #identity-icon
+{
+    list-style-image: var(--info-icon) !important;
+}
+
+/* warning (dangerous) */
+#identity-box[pageproxystate="valid"]:-moz-any(.notSecure, .weakCipher, .certUserOverridden, .certErrorPage, .insecureLoginForms, .mixedActiveContent) > #identity-icon
+{
+    list-style-image: var(--warning-icon) !important;
 }
 
 /* high DPI adjustments */


### PR DESCRIPTION
Adjusts the connection security icons to appear properly (Chrome-like) on:

- https
- http*
- mixed https*
- connection warnings**
- non-branded internal pages

The classes are taken from and tested with Firefox 72 Nightly browser.css.

`*` Since Firefox no longer actually differentiates between http and http with forms, also the "not secure" text is not enabled by default (and maybe never will), I made a change to differentiate http and mixed https: http is a gray warning triangle and mixed https is an info icon. That is similar to what Chrome is experimenting with - see `chrome://flags/#enable-mark-http-as` for more info.

`**` This is only for things like [expired certificate](https://expired.badssl.com/), [Google Safebrowsing](https://testsafebrowsing.appspot.com/) does not use a special icon yet as on Chrome (so it is just an info icon).