### PR TITLE
Change toolbar selected text and border color; Add bookmark icon

### DIFF
--- a/chrome/global/variables.css
+++ b/chrome/global/variables.css
@@ -126,6 +126,10 @@
 	
 	--toolbar-non-lwt-bgcolor: var(--toolbar-bgcolor) !important;
 	--toolbar-non-lwt-textcolor: var(--toolbar-color) !important;
+
+	--toolbar-field-focus-border-color: #b9d5f8 !important;
+	
+	--toolbar-selected-text-bgcolor: #aecbfa;
 }
 
 #titlebar,

--- a/chrome/icons/bookmark-folder.svg
+++ b/chrome/icons/bookmark-folder.svg
@@ -1,0 +1,9 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg width="16" height="16" viewBox="0 0 16 16" fill="context-fill" fill-opacity="context-fill-opacity" xmlns="http://www.w3.org/2000/svg">
+  <path d="M14.5 3H6.914a.5.5 0 0 1-.354-.146L5.146 1.439A1.491 1.491 0 0 0 4.086 1H1.5A1.5 1.5 0 0 0 0 2.5v11A1.5 1.5 0 0 0 1.5 15h13a1.5 1.5 0 0 0 1.5-1.5v-9A1.5 1.5 0 0 0 14.5 3zm.5 10.5a.5.5 0 0 1-.5.5h-13a.5.5 0 0 1-.5-.5V6h14zM1 5V2.5a.5.5 0 0 1 .5-.5h2.586a.5.5 0 0 1 .354.146l1.414 1.415A1.491 1.491 0 0 0 6.914 4H14.5a.5.5 0 0 1 .5.5V5z" fill="#ECC849"/>
+  <path d="M15 13.5a.5.5 0 0 1-.5.5h-13a.5.5 0 0 1-.5-.5V6h14z" fill="#FFE793"/>
+  <path d="M1 5V2.5a.5.5 0 0 1 .5-.5h2.586a.5.5 0 0 1 .354.146l1.414 1.415A1.491 1.491 0 0 0 6.914 4H14.5a.5.5 0 0 1 .5.5V5z" fill-opacity=".1" fill="yellow"/>
+  <path d="M15 13.5a.5.5 0 0 1-.5.5h-13a.5.5 0 0 1-.5-.5V13h14z" fill-opacity=".05" fill="yellow"/>
+</svg>

--- a/chrome/icons/icons.css
+++ b/chrome/icons/icons.css
@@ -325,3 +325,7 @@ richlistitem[originaltype="loginsFooter"] .ac-site-icon
 		list-style-image: url(library-2x.svg) !important;
 	}
 }
+
+.bookmark-item[container] {
+	list-style-image: url("bookmark-folder.svg") !important;
+}

--- a/chrome/urlbar/urlbar.css
+++ b/chrome/urlbar/urlbar.css
@@ -733,6 +733,10 @@
 	--input-offset: -1px;
 }
 
+#urlbar-input::selection {
+	background-color: var(--toolbar-selected-text-bgcolor);
+}
+
 /* 2x */
 @media (min--moz-device-pixel-ratio: 2)
 {


### PR DESCRIPTION
![图片](https://user-images.githubusercontent.com/5251264/74955826-2e523100-5440-11ea-8f48-2b255fed6bbf.png)
1. Add new bookmark icon by simply change the filling color of original Mozilla public icon;
2. Change border color and selected text color of the address bar