### PR TITLE
Stop tabs from shaking

### DIFF
--- a/chrome/tabbar/tabbar.css
+++ b/chrome/tabbar/tabbar.css
@@ -491,7 +491,7 @@
 
 #tabbrowser-tabs[overflow] .tabbrowser-tab[last-visible-tab]:not([pinned])
 {
-	margin-inline-end: 8px !important;
+	margin-inline-end: 7px !important;
 }
 
 .tabbrowser-tab[usercontextid] > .tab-stack::after


### PR DESCRIPTION
From https://github.com/muckSponge/MaterialFox/issues/218#issuecomment-633044844
and https://github.com/muckSponge/MaterialFox/issues/218#issuecomment-667512700  
- Change the inline margin for the last tab to 7px from 8px  

This stops tabs from shaking when the customize tab is opened and when over a certain number of tabs are opened.