### PR TITLE
Make field font size independent of theme

### DIFF
--- a/chrome/global/variables.css
+++ b/chrome/global/variables.css
@@ -38,8 +38,6 @@
 	
 	/* popup_highlight_text */
 	--autocomplete-popup-highlight-color: #202124 !important;
-	
-	--toolbar-field-fontsize: 14px !important;
 }
 
 /* don't bother with sidebar in light mode */
@@ -151,6 +149,8 @@
 	--toolbar-field-background-color: hsl(200, 12%, 95%) !important;
 	--toolbar-field-hover-background-color: hsl(216, 12%, 92%) !important;
 	--toolbar-field-focus-background-color: hsl(0, 0%, 100%) !important;
+	
+	--toolbar-field-fontsize: 14px !important;
 }
 
 :root:-moz-any(:-moz-lwtheme-brighttext, [privatebrowsingmode=temporary])


### PR DESCRIPTION
33571eb6c3fdda2ec27bdf9a18309cfe9d8a10e4 only added the field font size variable if the theme is set to light mode. This causes users in dark mode to see very small text, and the variable has no effect. This PR makes the variable available regardless of theme, using @fmeyertoens' suggestion to use the `:root` selector instead.