### PR TITLE
Fixed URL address text padding when urlbar is in focus but not open.

### DIFF
--- a/chrome/urlbar/urlbar.css
+++ b/chrome/urlbar/urlbar.css
@@ -205,7 +205,7 @@
 {
 	/* -moz-accent-color won't work in a var... */
 	border: 2px solid -moz-accent-color !important;
-	padding: 0 !important;
+	padding: 0 auto !important;
 	margin: 0 !important;
 }
 


### PR DESCRIPTION
**Describe the bug**
The vertical padding (specifically top padding) of the URL address text is incorrect within its container when you open or switch to a new tab and have focus on the search bar.

**To Reproduce**
Steps to reproduce the behavior:
1. Install MaterialFox `chrome` folder and `user.js` to profile root directory
2. Restart Firefox
3. Open new tab **or** click on address bar -> switch tabs -> return back to original tab (make sure you are not in the focus mode where it shows you autocomplete suggestions list)

**Screenshot BEFORE fix**
Look at the URL text inside the address bar...
<img width="836" alt="Screen Shot 2022-07-24 at 3 08 47 PM" src="https://user-images.githubusercontent.com/54961512/180664038-160060fe-3e6c-4684-ab52-5c81e28ef509.png">
**System info**
 - OS: MacOS
 - Firefox version: 103.0b9

**How I fixed it**
On line `#208` in `chrome/urlbar/urlbar.css`, I separated the horizontal and vertical padding values for the URL address text within the address bar. I noticed that it was setting ALL padding (every direction) to 0 but the desired styling was 0 padding for the horizontal directions (left and right) and automatic (evenly spaced) padding for the vertical directions (top and bottom). Below is the line of code I changed:

```
from
	padding: 0 !important;
to
	padding: 0 auto !important;
```

**Screenshot AFTER fix**
Look at the URL text inside the address bar...
<img width="836" alt="Screen Shot 2022-07-24 at 3 34 29 PM" src="https://user-images.githubusercontent.com/54961512/180665129-550d5272-a4c6-4355-89e8-7060f583a54c.png">

Hope this helps!