### PR TITLE
Fix: tab bar height, new tab button alignment and multi-account containers colored bar

### DIFF
--- a/chrome/tabbar/tabbar.css
+++ b/chrome/tabbar/tabbar.css
@@ -126,7 +126,7 @@
 
 .tab-stack
 {
-	margin-top: 4px !important;
+	margin-top: -4px !important;
 	margin-bottom: -4px !important;
 }
 
@@ -489,7 +489,9 @@
 
 #tabbrowser-tabs #tabs-newtab-button
 {
-	margin-inline-start: 6px !important;
+	margin-inline-start: 4px !important;
+	margin-bottom: 4px !important;
+	margin-top: 4px !important;
 }
 
 #tabbrowser-tabs[overflow] .tabbrowser-arrowscrollbox
@@ -524,7 +526,7 @@
 	bottom: 0 !important;
 	left: 8px !important;
 	width: calc(100% - 16px) !important;
-	height: 2px !important;
+	height: 6px !important;
 	box-sizing: border-box !important;
 	border-radius: 99px 99px 0 0 !important;
 	transform: none !important;
@@ -541,7 +543,7 @@
 
 .tabbrowser-tab[usercontextid][selected] > .tab-stack::after
 {
-	bottom: calc(100% - 9px) !important;
+	bottom: calc(90% - 9px) !important;
 	left: calc(100% - 9px) !important;
 	width: 6px !important;
 	height: 6px !important;

--- a/chrome/userChrome.css
+++ b/chrome/userChrome.css
@@ -7,3 +7,8 @@
 @import "popup/popup.css";
 @import "urlbar/urlbar.css";
 @import "findbar/findbar.css";
+
+/*move multi-account container color to the bottom of the tab*/
+.tab-context-line {
+  margin: var(--tab-min-height) var(--inline-tab-padding) 0 !important;
+}


### PR DESCRIPTION
The tab bar height is fixed by editing the margin:

In `chrome\tabbar\tabbar.css`

 change the following:

```
Line 129:

from:
margin-top: 4px !important;

to:
margin-top: -4px !important;
```
![2022-08-13 14_22_45-NVIDIA GeForce Overlay DT](https://user-images.githubusercontent.com/52209210/184494049-0ade3164-1b89-491b-840e-b73c40224324.png)

The new tab button will be misaligned, to fix: 

```
Line 492:

from:
margin-inline-start: 6px !important;

to:
margin-inline-start: 4px !important;
margin-bottom: 4px !important;
margin-top: 4px !important;

```
The tab before:
![2022-08-13 13_45_52-NVIDIA GeForce Overlay DT](https://user-images.githubusercontent.com/52209210/184494112-b408a6d9-b832-411e-b63d-d4a9a976b622.png)

The tab after:
![2022-08-13 13_46_37-NVIDIA GeForce Overlay DT](https://user-images.githubusercontent.com/52209210/184494128-db53918d-3015-447d-973f-08696b68299b.png)

> If you find any issue in your browser you can edit the margins to your liking.

If you use multi-account containers you will see that the colored bar at the bottom of the tab is either gone or it's gone when switching to another tab, to fix:

In `chrome\userChrome.css`

add the following:
```
/*move multi-account containers color to the bottom of the tab*/
.tab-context-line {
  margin: var(--tab-min-height) var(--inline-tab-padding) 0 !important;
}
```
In `chrome\tabbar\tabbar.css`

 change the following:

```
Line 529:

from:
height: 2px !important;

to:
height: 6px !important;

```
```
Line 546:

from:
bottom: calc(100% - 9px) !important;

to:
bottom: calc(90% - 9px) !important;

```

Before:
![2022-08-13 13_51_08-NVIDIA GeForce Overlay DT](https://user-images.githubusercontent.com/52209210/184494328-f9833015-cbd6-4064-a4a3-736c6ebeeb77.png)

After:
![2022-08-13 13_53_24-NVIDIA GeForce Overlay DT](https://user-images.githubusercontent.com/52209210/184494359-2889706a-3cfe-4f05-8fa5-b6e34818bc3e.png)


