### PR TITLE
Fix alignment of forward and back buttons

### DIFF
--- a/chrome/icons/icons.css
+++ b/chrome/icons/icons.css
@@ -31,7 +31,7 @@
 .toolbarbutton-1#forward-button .toolbarbutton-icon,
 #context-forward .menu-iconic-icon
 {
-	transform: scaleX(-1) !important;
+	transform: translate(0px, -0.5px) scaleX(-1) !important;
 }
 
 #home-button


### PR DESCRIPTION
I noticed that the forward and back buttons were misaligned because one is just a mirrored version of the other, and I guess the svg isn't perfectly centered. It was bugging me so I fixed it:

Old forward and back buttons, this is from the readme:
![Old forward and back buttons](https://i.imgur.com/zzBH0OP.png)

New forward and back buttons:
![New forward and back buttons](https://i.imgur.com/fLvqJCI.png)