### PR TITLE
Re-center tab separator

### DIFF
--- a/chrome/tabbar/tabbar.css
+++ b/chrome/tabbar/tabbar.css
@@ -158,7 +158,7 @@
 	background-color: currentColor !important;
 	width: 1px !important;
 	height: 20px !important;
-	transform: translateY(-10px) !important;
+	transform: translateY(10px) !important;
 	opacity: 0 !important;
 	transition: opacity .2s var(--ease-basic) !important;
 }


### PR DESCRIPTION
The tab separator isn't fully centered, but changing the 'translateY' property from `-10px` to `10px` should re-center it.

**Before:**
<img width="506" alt="image" src="https://user-images.githubusercontent.com/91700492/209005318-09a7bd46-9bf5-4160-8594-82ef1e308f77.png">
**After:**
<img width="451" alt="image" src="https://user-images.githubusercontent.com/91700492/209005182-c3d00b61-7b8b-4a40-912f-8d152c834d78.png">
